### PR TITLE
Fix code generation in modules with forbid(missing_docs)

### DIFF
--- a/enum-kinds/tests/kinds.rs
+++ b/enum-kinds/tests/kinds.rs
@@ -72,6 +72,18 @@ enum WithExtraTraitsMultiple {
     Second(String)
 }
 
+mod forbids_missing_docs {
+    #![forbid(missing_docs)]
+
+    #[derive(EnumKind)]
+    #[enum_kind(WithDocumentationKind, doc = "a documented kind enum")]
+    #[allow(dead_code)]
+    enum WithDocumentation {
+        First(u32, u32),
+        Second(String),
+    }
+}
+
 #[test]
 fn test_unnamed() {
     let first = UnnamedEnum::First("Example".to_owned(), 32);


### PR DESCRIPTION
This PR makes enum_kinds optionally omit the `allow(missing_docs)` attribute, the presence of which causes compiles to fail if you derive EnumKind in a module with `forbid(missing_docs)` on: There, any `#[allow(missing_docs)]` attribute is an error. The first commit here demonstrates the failure to compile that I mean (:

Instead, the derive macro now checks if a `doc =` attribute was passed. If so, it omits the `allow(missing_docs)` attr, as the enum counts as documented. 

In this PR, we also drop generating the `allow(missing_docs)` attribute from the `From` trait impl, as this does not count as an undocumented item, and adding it again clashes with the corresponding forbid.