### PR TITLE
Allow the user to specify custom discriminant values

### DIFF
--- a/enum-kinds/README.md
+++ b/enum-kinds/README.md
@@ -65,6 +65,26 @@ enum AdditionalDerives {
 }
 ```
 
+# Custom Discriminant Values
+
+By default, derived kind enums do not specify values for the variants. To
+specify values, use the `enum_kind_value` attribute: `#[enum_kind_value(10)]`.
+For example,
+
+``` rust,ignore
+#[macro_use]
+extern crate enum_kinds;
+
+#[derive(EnumKind)]
+#[enum_kind(WithValuesKind)]
+enum WithValues {
+    #[enum_kind_value(10)]
+    Ten(String, u32),
+    #[enum_kind_value(20)]
+    Twenty(String)
+}
+```
+
 # no_std support
 
 `enum-kinds` can be used without the standard library by enabling `no-stdlib`

--- a/enum-kinds/tests/kinds.rs
+++ b/enum-kinds/tests/kinds.rs
@@ -72,6 +72,17 @@ enum WithExtraTraitsMultiple {
     Second(String),
 }
 
+#[derive(EnumKind)]
+#[enum_kind(WithValuesKind)]
+#[allow(dead_code)]
+enum WithValues {
+    #[enum_kind_value(10)]
+    Ten,
+    #[enum_kind_value(20)]
+    Twenty,
+    TwentyOne,
+}
+
 mod forbids_missing_docs {
     #![forbid(missing_docs)]
 
@@ -132,4 +143,11 @@ fn test_with_extra_traits_multiple() {
     let first = WithExtraTraitsMultiple::First(20, 30);
     let kind: WithExtraTraitsMultipleKind = first.into();
     serde_json::to_string(&kind).unwrap();
+}
+
+#[test]
+fn test_with_values() {
+    let twentyone = WithValues::TwentyOne;
+    let kind: WithValuesKind = twentyone.into();
+    assert_eq!(kind as usize, 21);
 }


### PR DESCRIPTION
I found this useful in a parser situation, where I needed to control the serialization of the generated enum.